### PR TITLE
Handle the mail server move or removal

### DIFF
--- a/imageroot/actions/configure-module/10EnvRouncubemail
+++ b/imageroot/actions/configure-module/10EnvRouncubemail
@@ -13,9 +13,12 @@ import agent.tasks
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
+# Connect to redis
+rdb = agent.redis_connect()
 
 # Setup default values
 mail_server = data["mail_server"]
+module_uuid = rdb.hget(f"module/{mail_server}/srv/tcp/submission", "module_uuid") or ""
 
 plugins = 'archive,zipdownload,managesieve,markasjunk,' + data.get("plugins",'')
 upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
@@ -23,6 +26,7 @@ upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
 # Talk with agent using file descriptor.
 # Setup configuration from user input.
 agent.set_env("MAIL_SERVER", mail_server)
+agent.set_env("MAIL_MODULE_UUID", module_uuid)
 agent.set_env("ROUNDCUBEMAIL_PLUGINS", plugins)
 agent.set_env("ROUNDCUBEMAIL_PLUGINS_NETHSERVER", data.get("plugins",''))
 agent.set_env("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE", upload_max_filesize)

--- a/imageroot/actions/configure-module/10EnvRouncubemail
+++ b/imageroot/actions/configure-module/10EnvRouncubemail
@@ -9,19 +9,13 @@ import json
 import sys
 import agent
 import agent.tasks
-import os
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
 
-# Connect to redis
-rdb = agent.redis_connect()
-
 # Setup default values
 mail_server = data["mail_server"]
-smtp_server = rdb.hget(f"module/{mail_server}/srv/tcp/submission", "host") or ""
-imap_server = rdb.hget(f"module/{mail_server}/srv/tcp/imap", "host") or ""
 
 plugins = 'archive,zipdownload,managesieve,markasjunk,' + data.get("plugins",'')
 upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
@@ -29,8 +23,6 @@ upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
 # Talk with agent using file descriptor.
 # Setup configuration from user input.
 agent.set_env("MAIL_SERVER", mail_server)
-agent.set_env("ROUNDCUBEMAIL_DEFAULT_HOST", imap_server)
-agent.set_env("ROUNDCUBEMAIL_SMTP_SERVER", smtp_server)
 agent.set_env("ROUNDCUBEMAIL_PLUGINS", plugins)
 agent.set_env("ROUNDCUBEMAIL_PLUGINS_NETHSERVER", data.get("plugins",''))
 agent.set_env("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE", upload_max_filesize)

--- a/imageroot/actions/configure-module/30EnableCustomConfigurations
+++ b/imageroot/actions/configure-module/30EnableCustomConfigurations
@@ -5,30 +5,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import json
-import sys
-import agent
-import agent.tasks
-import os
-
-# Try to parse the stdin as JSON.
-# If parsing fails, output everything to stderr
-data = json.load(sys.stdin)
-
-# Setup default values
-rdb = agent.redis_connect()
-
-# Setup default values
-mail_server = data["mail_server"]
-mail_server = rdb.hget(f"module/{mail_server}/srv/tcp/imap", "host") or ""
-
+#
+# Write default settings of roundcubemail
+#
 with open("config/config.nethserver.php", "w") as f:
     f.write("<?php \n")
     # we need a full email adress with foo@domain.com
     f.write("$config['login_username_filter'] = 'email'; \n")
     # allow the browser to save login/credential and to fill them
     f.write("$config['login_autocomplete'] = 2; \n")
-
-with open("config/config.managesieve.php", "w") as f:
-    f.write("<?php\n")
-    f.write("$config['managesieve_host'] = '"+mail_server+":4190';\n")

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -17,7 +17,8 @@ for evar in [
         "TRAEFIK_HOST",
         "TRAEFIK_HTTP2HTTPS",
         "TRAEFIK_LETS_ENCRYPT",
-        "MAIL_SERVER"
+        "MAIL_SERVER",
+        "MAIL_MODULE_UUID",
         "ROUNDCUBEMAIL_DEFAULT_HOST",
         "ROUNDCUBEMAIL_SMTP_SERVER",
         "ROUNDCUBEMAIL_PLUGINS",

--- a/imageroot/bin/discover-service
+++ b/imageroot/bin/discover-service
@@ -6,7 +6,7 @@
 #
 
 #
-# Find port of mail service
+# Find settings (port, ip, ..) of mail service among the cluster
 #
 
 import os
@@ -20,6 +20,9 @@ rdb = agent.redis_connect(host="127.0.0.1") # full read-only access on every key
 # we query about TCP service provided by the mail server
 smtp_port = rdb.hget(f"module/{mail_server}/srv/tcp/submission", "port") or ""
 imap_port = rdb.hget(f"module/{mail_server}/srv/tcp/imap", "port") or ""
+# we query about the IP in the cluster of the mail server
+smtp_server = rdb.hget(f"module/{mail_server}/srv/tcp/submission", "host") or ""
+imap_server = rdb.hget(f"module/{mail_server}/srv/tcp/imap", "host") or ""
 
 envfile = "roundcubemail_default_port.env"
 
@@ -28,6 +31,13 @@ envfile = "roundcubemail_default_port.env"
 with open(envfile + ".tmp", "w") as efp:
     print(f"ROUNDCUBEMAIL_DEFAULT_PORT={imap_port}", file=efp)
     print(f"ROUNDCUBEMAIL_SMTP_PORT={smtp_port}", file=efp)
+    print(f"ROUNDCUBEMAIL_DEFAULT_HOST={imap_server}", file=efp)
+    print(f"ROUNDCUBEMAIL_SMTP_SERVER={smtp_server}", file=efp)
 
 # Commit changes by replacing the existing envfile:
 os.replace(envfile + ".tmp", envfile)
+
+# we need to expand the IP of mail server in sieve file
+with open("config/config.managesieve.php", "w") as f:
+    f.write("<?php\n")
+    f.write("$config['managesieve_host'] = '"+imap_server+":4190';\n")

--- a/imageroot/events/mail-settings-changed/00Event-validation
+++ b/imageroot/events/mail-settings-changed/00Event-validation
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import json
+import os
+
+event_input = json.load(sys.stdin)
+
+if (event_input['module_uuid'] == os.getenv('MAIL_MODULE_UUID')
+    and event_input['reason'] == 'destroy-module'):
+    # the mail server has been removed we stop
+    sys.exit(2)

--- a/imageroot/events/mail-settings-changed/10change-mail-provider
+++ b/imageroot/events/mail-settings-changed/10change-mail-provider
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+import os
+
+event = json.load(sys.stdin)
+
+mail_server = event['module_id']
+module_uuid = event['module_uuid']
+
+# Talk with agent using file descriptor.
+# Setup configuration from user input.
+agent.set_env("MAIL_SERVER", mail_server)
+agent.set_env("MAIL_MODULE_UUID", module_uuid)
+
+# Make sure everything is saved inside the environment file
+# just before starting systemd unit
+agent.dump_env()

--- a/imageroot/events/mail-settings-changed/80start_services
+++ b/imageroot/events/mail-settings-changed/80start_services
@@ -10,4 +10,4 @@ set -e
 exec 1>&2 # Send any output to stderr, to not alter the action response protocol
 
 # If the control reaches this step, the service can be enabled and started
-systemctl --user restart roundcubemail.service
+systemctl --user  try-restart roundcubemail.service

--- a/imageroot/events/mail-settings-changed/80start_services
+++ b/imageroot/events/mail-settings-changed/80start_services
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+exec 1>&2 # Send any output to stderr, to not alter the action response protocol
+
+# If the control reaches this step, the service can be enabled and started
+systemctl --user restart roundcubemail.service


### PR DESCRIPTION
When the mail server is destroyed or moved someplace in the cluster we trigger an event mail-settings-changed that roundcubemail must be aware to adjust its settings