### PR TITLE
Persistent relation with the Mail backend module

### DIFF
--- a/imageroot/actions/configure-module/01Hostname_validation
+++ b/imageroot/actions/configure-module/01Hostname_validation
@@ -13,6 +13,7 @@ import urllib.request
 import urllib.error
 import ssl
 
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
 
 # retrieve json data
 data = json.load(sys.stdin)
@@ -22,40 +23,7 @@ host = data.get("host")
 # do not test if it is the same host
 oldHost = os.environ.get('TRAEFIK_HOST','')
 
-if host == oldHost:
-    exit(0)
-
-# set error validation
-agent.set_weight(os.path.basename(__file__), 0)
-
-http = 0
-https = 0
-
-# do not verify the certificate
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-# try on http
-try:
-    req = urllib.request.Request('http://127.0.0.1')
-    req.add_header('Host', host)
-    urllib.request.urlopen(req, context=ctx)
-except urllib.error.HTTPError as e:
-    http = e.code
-
-# try on https
-try:
-    req = urllib.request.Request('https://127.0.0.1')
-    req.add_header('Host', host)
-    urllib.request.urlopen(req, context=ctx)
-except urllib.error.HTTPError as d:
-    https = d.code
-
-if http == 404 and  https == 404:
-    # there is no website on http or https -> OK
-    exit(0)
-else:
-    # path exists -> nok
+if host != oldHost and agent.http_route_in_use(domain=host):
     agent.set_status('validation-failed')
     json.dump([{'field':'host','parameter':'host','value':host,'error':'domain_already_used_in_traefik'}],fp=sys.stdout)
     sys.exit(2)

--- a/imageroot/actions/configure-module/02mail_server_validation
+++ b/imageroot/actions/configure-module/02mail_server_validation
@@ -19,8 +19,11 @@ data = json.load(sys.stdin)
 # Connect to redis
 rdb = agent.redis_connect()
 
-mail_server = data["mail_server"]
-if not rdb.exists(f"module/{mail_server}/srv/tcp/imap"):
-        agent.set_status('validation-failed')
-        json.dump([{'field':'mail_server','parameter':'mail_server','value': data["mail_server"],'error':'mail_server_is_not_valid'}], fp=sys.stdout)
-        sys.exit(3)
+providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
+    'module_uuid': data["mail_server"],
+})
+
+if not providers:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'mail_server','parameter':'mail_server','value': data["mail_server"],'error':'mail_server_is_not_valid'}], fp=sys.stdout)
+    sys.exit(3)

--- a/imageroot/actions/configure-module/10EnvRouncubemail
+++ b/imageroot/actions/configure-module/10EnvRouncubemail
@@ -8,28 +8,18 @@
 import json
 import sys
 import agent
-import agent.tasks
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
-# Connect to redis
-rdb = agent.redis_connect()
-
-# Setup default values
-mail_server = data["mail_server"]
-module_uuid = rdb.hget(f"module/{mail_server}/srv/tcp/submission", "module_uuid") or ""
 
 plugins = 'archive,zipdownload,managesieve,markasjunk,' + data.get("plugins",'')
 upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
 
-# Talk with agent using file descriptor.
 # Setup configuration from user input.
-agent.set_env("MAIL_SERVER", mail_server)
-agent.set_env("MAIL_MODULE_UUID", module_uuid)
+agent.set_env("MAIL_SERVER", data["mail_server"])
 agent.set_env("ROUNDCUBEMAIL_PLUGINS", plugins)
 agent.set_env("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE", upload_max_filesize)
-
 
 # Make sure everything is saved inside the environment file
 # just before starting systemd unit

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -8,7 +8,7 @@
             "host": "roundcubemail.domain.org",
             "http2https": true,
             "lets_encrypt": true,
-            "mail_server":"mail1",
+            "mail_server": "9b9a7388-a661-4399-a7d2-c2ab08f4227c",
             "plugins":"archive,zipdownload",
             "upload_max_filesize":10
         }
@@ -41,7 +41,7 @@
         "mail_server": {
             "type": "string",
             "title": "mail_server",
-            "description": "module_id of the mail server like 'mail1'"
+            "description": "module_uuid of the mail server like 9b9a7388-a661-4399-a7d2-c2ab08f4227c"
         },
         "plugins": {
             "type": "string",

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -24,14 +24,7 @@ config["lets_encrypt"] = os.getenv("TRAEFIK_LETS_ENCRYPT") == "True"
 
 rdb = agent.redis_connect() # full read-only access on every key
 
-imap = agent.list_service_providers(rdb, 'imap', 'tcp', {
-    'module_uuid': os.getenv('MAIL_MODULE_UUID', '')
-})
-
-# we try first to use MAIL_MODULE_UUID  (module_uuid of mail server) 
-# failback to MAIL_SERVER (module_id of mail server)
-config["mail_server"] = imap[0]['module_id'] if imap else os.getenv('MAIL_SERVER', '')
-
+config["mail_server"] = os.getenv("MAIL_SERVER", "") # the value is the Mail module UUID!
 config["plugins"] = os.getenv("ROUNDCUBEMAIL_PLUGINS","")
 config["upload_max_filesize"] = os.getenv("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE","10").replace('M','')
 
@@ -39,14 +32,11 @@ modules=[]
 
 # we query about all mail server to use it inside the user interface
 for key in agent.list_service_providers(rdb,'imap','tcp'):
-    # we query agent about configured mail server 
-    modules.append(
-                {
-                    "name": key['module_id'],
-                    "label": key['module_id']+' (NODE '+key['node']+') '+ key['mail_hostname'],
-                    "value": key['module_id']
-                }
-    )
+    modules.append({
+        "name": key['module_id'],
+        "label": key['mail_hostname'],
+        "value": key['module_uuid'],
+    })
 
 # use it inside a dropdown
 config['mail_server_URL'] = modules

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -8,7 +8,8 @@
             "host": "roundcubemail.domain.org",
             "http2https": true,
             "lets_encrypt": true,
-            "mail_server": "mail1",
+            "mail_server": "9b9a7388-a661-4399-a7d2-c2ab08f4227c",
+            "mail_server_URL": [],
             "plugins": "archive,zipdownload",
             "upload_max_filesize": 10
         }
@@ -47,7 +48,7 @@
         "mail_server": {
             "type": "string",
             "title": "mail_server",
-            "description": "module_id of the mail server like 'mail1'"
+            "description": "module_uuid of the mail server like 9b9a7388-a661-4399-a7d2-c2ab08f4227c"
         },
         "plugins": {
             "type": "string",

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -17,7 +17,6 @@ for evar in [
         "TRAEFIK_HOST",
         "TRAEFIK_HTTP2HTTPS",
         "TRAEFIK_LETS_ENCRYPT",
-        "MAIL_MODULE_UUID",
         "MAIL_SERVER",
         "ROUNDCUBEMAIL_PLUGINS",
         "ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE",

--- a/imageroot/actions/restore-module/60systemd
+++ b/imageroot/actions/restore-module/60systemd
@@ -10,5 +10,5 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-# Enable and restart the service
+# Enable and start the service
 systemctl --user enable --now roundcubemail.service

--- a/imageroot/actions/update-module.d/20restart
+++ b/imageroot/actions/update-module.d/20restart
@@ -4,4 +4,11 @@
 # Copyright (C) 2022 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-systemctl --user restart roundcubemail.service
+
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+# Restart if running, ignore if stopped
+systemctl --user try-restart roundcubemail.service

--- a/imageroot/bin/discover-service
+++ b/imageroot/bin/discover-service
@@ -14,43 +14,39 @@ import sys
 import json
 import agent
 
-rdb = agent.redis_connect(host="127.0.0.1") # full read-only access on every key
-
+# This script must rely on local node resources to ensure service startup
+# even if the leader node is not reachable: connect to local Redis
+# replica.
+rdb = agent.redis_connect(use_replica=True)
 
 imap = agent.list_service_providers(rdb, 'imap', 'tcp', {
-    'module_id': os.getenv('MAIL_SERVER', '')
+    'module_uuid': os.environ['MAIL_SERVER']
 })
 
-if not imap:
-    imap = agent.list_service_providers(rdb, 'imap', 'tcp', {
-        'module_uuid': os.getenv('MAIL_MODULE_UUID', '')
-    })
-
+if len(imap) != 1:
+    # Only ONE provider for the same UUID is allowed. Zero means it is
+    # missing. More than one means the DB is inconsistent.
+    print(agent.SD_ERR + "Cannot find the imap service of my Mail module instance", os.environ['MAIL_SERVER'], file=sys.stderr)
+    sys.exit(4)
 
 smtp = agent.list_service_providers(rdb, 'submission', 'tcp', {
-    'module_id': os.getenv('MAIL_SERVER', '')
+    'module_uuid': os.getenv('MAIL_SERVER', '')
 })
 
-if not smtp:
-    smtp = agent.list_service_providers(rdb, 'submission', 'tcp', {
-        'module_uuid': os.getenv('MAIL_MODULE_UUID', '')
-    })
+if len(smtp) != 1:
+    # Only ONE provider for the same UUID is allowed. Zero means it is
+    # missing. More than one means the DB is inconsistent.
+    print(agent.SD_ERR + "Cannot find the submission service of my Mail module instance", os.environ['MAIL_SERVER'], file=sys.stderr)
+    sys.exit(5)
 
-if imap:
-    imap_port = imap[0]['port']
-    imap_server = imap[0]['host']
-    user_domain = imap[0]['user_domain']
-else:
-    sys.exit(2)
+imap_port = imap[0]['port']
+imap_server = imap[0]['host']
+user_domain = imap[0]['user_domain']
 
-if smtp:
-    smtp_port = smtp[0]['port']
-    smtp_server = smtp[0]['host']
-else:
-    sys.exit(3)
+smtp_port = smtp[0]['port']
+smtp_server = smtp[0]['host']
 
-
-envfile = "roundcubemail_default_network.env"
+envfile = "discovery.env"
 
 # Using .tmp suffix: do not overwrite the target file until the new one is
 # saved to disk:

--- a/imageroot/events/mail-settings-changed/80start_services
+++ b/imageroot/events/mail-settings-changed/80start_services
@@ -11,6 +11,7 @@ import agent
 import os
 
 event = json.load(sys.stdin)
-# if the mail server has been removed, we try to discover the new mail server
+
 if event['module_uuid'] == os.getenv('MAIL_MODULE_UUID', ''):
-   agent.run_helper("systemctl", "--user", "try-restart", "roundcubemail.service").check_returncode()
+   # Restart to apply changed settings
+   agent.run_helper("systemctl", "--user", "try-restart", "roundcubemail-app.service").check_returncode()

--- a/imageroot/systemd/user/roundcubemail-app.service
+++ b/imageroot/systemd/user/roundcubemail-app.service
@@ -17,7 +17,7 @@ Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/mkdir -p config
 ExecStartPre=/bin/rm -f %t/roundcubemail-app.pid %t/roundcubemail-app.ctr-id
-ExecStartPre=-/usr/local/bin/runagent discover-service
+ExecStartPre=/usr/local/bin/runagent discover-service
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/roundcubemail-app.pid \
     --cidfile %t/roundcubemail-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/roundcubemail.pod-id --replace -d --name  roundcubemail-app \

--- a/imageroot/systemd/user/roundcubemail-app.service
+++ b/imageroot/systemd/user/roundcubemail-app.service
@@ -11,7 +11,7 @@ After=roundcubemail.service mariadb-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/roundcubemail_default_network.env
+EnvironmentFile=-%S/state/discovery.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70

--- a/imageroot/systemd/user/roundcubemail-app.service
+++ b/imageroot/systemd/user/roundcubemail-app.service
@@ -15,14 +15,14 @@ EnvironmentFile=-%S/state/roundcubemail_default_network.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
-ExecStartPre=/bin/mkdir -p %S/state/config
+ExecStartPre=/bin/mkdir -p config
 ExecStartPre=/bin/rm -f %t/roundcubemail-app.pid %t/roundcubemail-app.ctr-id
 ExecStartPre=-/usr/local/bin/runagent discover-service
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/roundcubemail-app.pid \
     --cidfile %t/roundcubemail-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/roundcubemail.pod-id --replace -d --name  roundcubemail-app \
     --volume html:/var/www/html/:Z \
-    --volume  %S/state/config:/var/roundcube/config/:Z \
+    --volume ./config:/var/roundcube/config:Z \
     --env=ROUNDCUBEMAIL_* \
     --env ROUNDCUBEMAIL_DB_TYPE=mysql \
     --env ROUNDCUBEMAIL_DB_HOST=127.0.0.1 \


### PR DESCRIPTION
Roundcube needs a Mail module instance as backend to work. This PR wants to use the Mail module UUID to store a durable reference to it.

**Why not MODULE_ID?**

- if Mail is cloned/moved its MODULE_ID (e.g. mail1) changes
- same if Mail is restored from the backup

**Alternatives**

The `mail_hostname` field is pushed in the srv Redis key too (still not documented in ns8-mail README). It is a good candidate as an universal unique identifier because a configuration where two Mail instances have the same host name does not make sense.

However MODULE_UUID is safer.

----

**Other changes**

- The `discover-service` script relies on MAIL_SERVER as a string containing the Mail MODULE_UUID.
- Use the library function to validate the Traefik route
- Other minor changes, see individual commits

**Still missing**

Backup scripts, `module-dump-state` and `module-cleanup-state`, for a separate PR.