### PR TITLE
Force to use the username_domain value for the user login

### DIFF
--- a/imageroot/bin/discover-service
+++ b/imageroot/bin/discover-service
@@ -72,6 +72,7 @@ with open("config/config.nethserver.php", "w") as f:
     # we want to prefill with user_domain of list_service_providers
     if imap_server and user_domain:
         f.write("$config['username_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
+        f.write("$config['username_domain_forced'] = true; \n")
         f.write("$config['mail_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
     # allow the browser to save login/credential and to fill them
     f.write("$config['login_autocomplete'] = 2; \n")


### PR DESCRIPTION
Force domain configured in username_domain to be used for login. Any domain in username will be replaced by username_domain.

![image](https://user-images.githubusercontent.com/3164851/212385385-26de545f-20e6-4fc4-aef0-7e4d1e694d0d.png)

![image](https://user-images.githubusercontent.com/3164851/212385271-abdce9bb-bb23-4128-a92c-0b84936b1c42.png)
