### PR TITLE
configure-module. Add `mail_domain` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Launch `configure-module`, by setting the following parameters:
 - `host`: a fully qualified domain name for the application
 - `http2https`: enable or disable HTTP to HTTPS redirection (true/false)
 - `lets_encrypt`: enable or disable Let's Encrypt certificate (true/false)
-- `mail_server`: the module ID of the the mail server (only on NS8), for example `mail1`
+- `mail_server`: the module UUID of the the mail server (only on NS8), for example `24c52316-5af5-4b4d-8b0f-734f9ee9c1d9`
+- `mail_domain`: the mail domain used for user IMAP login and Roundcube user identifier. It must
+  correspond to a valid mail domain handled by `mail_server` where user names are valid mail addresses too
 - `plugins`: a list of plugins(coma separated) to enable in roundcubemail (default enabled : `archive,zipdownload,managesieve,markasjunk`)
 - `upload_max_filesize`: The maximum size of attachment in MB (default 5MB)
 

--- a/imageroot/actions/configure-module/10EnvRouncubemail
+++ b/imageroot/actions/configure-module/10EnvRouncubemail
@@ -20,6 +20,10 @@ upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
 agent.set_env("MAIL_SERVER", data["mail_server"])
 agent.set_env("ROUNDCUBEMAIL_PLUGINS", plugins)
 agent.set_env("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE", upload_max_filesize)
+if "mail_domain" in data:
+    agent.set_env("MAIL_DOMAIN", data["mail_domain"])
+else:
+    agent.set_env("MAIL_DOMAIN", "")
 
 # Make sure everything is saved inside the environment file
 # just before starting systemd unit

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -43,6 +43,11 @@
             "title": "mail_server",
             "description": "module_uuid of the mail server like 9b9a7388-a661-4399-a7d2-c2ab08f4227c"
         },
+        "mail_domain": {
+            "type": "string",
+            "title": "mail_domain",
+            "description": "The mail domain used for user IMAP login and Roundcube user identifier. It must correspond to a valid mail domain handled by `mail_server` where user names are valid mail addresses too"
+        },
         "plugins": {
             "type": "string",
             "title": "plugins",

--- a/imageroot/bin/discover-service
+++ b/imageroot/bin/discover-service
@@ -41,7 +41,7 @@ if len(smtp) != 1:
 
 imap_port = imap[0]['port']
 imap_server = imap[0]['host']
-user_domain = imap[0]['user_domain']
+user_domain = os.getenv('MAIL_DOMAIN', imap[0]['user_domain'])
 
 smtp_port = smtp[0]['port']
 smtp_server = smtp[0]['host']


### PR DESCRIPTION
Allow to override the default user_domain value, used for IMAP login and as Roundcube user identifier: that value could be a non-valid mail domain (e.g. directory.nh).

This commit allows to select a mail domain, provided it considers user names as valid email addresses.