### PR TITLE
Fix the login without domain suffix

### DIFF
--- a/imageroot/actions/configure-module/10EnvRouncubemail
+++ b/imageroot/actions/configure-module/10EnvRouncubemail
@@ -20,10 +20,6 @@ upload_max_filesize = str(data.get("upload_max_filesize", '5')) + 'M'
 agent.set_env("MAIL_SERVER", data["mail_server"])
 agent.set_env("ROUNDCUBEMAIL_PLUGINS", plugins)
 agent.set_env("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE", upload_max_filesize)
-if "mail_domain" in data:
-    agent.set_env("MAIL_DOMAIN", data["mail_domain"])
-else:
-    agent.set_env("MAIL_DOMAIN", "")
 
 # Make sure everything is saved inside the environment file
 # just before starting systemd unit

--- a/imageroot/bin/discover-service
+++ b/imageroot/bin/discover-service
@@ -41,7 +41,7 @@ if len(smtp) != 1:
 
 imap_port = imap[0]['port']
 imap_server = imap[0]['host']
-user_domain = os.getenv('MAIL_DOMAIN', imap[0]['user_domain'])
+user_domain = imap[0]['user_domain']
 
 smtp_port = smtp[0]['port']
 smtp_server = smtp[0]['host']
@@ -70,9 +70,8 @@ with open("config/config.managesieve.php", "w") as f:
 with open("config/config.nethserver.php", "w") as f:
     f.write("<?php \n")
     # we want to prefill with user_domain of list_service_providers
-    if imap_server and user_domain:
-        f.write("$config['username_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
-        f.write("$config['username_domain_forced'] = true; \n")
-        f.write("$config['mail_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
+    f.write("$config['username_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
+    f.write("$config['username_domain_forced'] = true; \n")
+    f.write("$config['mail_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
     # allow the browser to save login/credential and to fill them
     f.write("$config['login_autocomplete'] = 2; \n")


### PR DESCRIPTION
Previously we could login to roundcubemail with titi and titi@domain.com

with the change of the Env var (not used anymore)  MAIL_DOMAIN, replaced by MAIL_SERVER we got a bug in the discover-service script

the issue is that we could login with titi user but it takes the email address titi@10.5.4.1 ( host value) and we are looking for to titi@rocky9-pve3.org (user_domain value). The main issue is that  titi@10.5.4.1 cannot send email, roundcubemail is complaining, probably also the smtp.

```
bash-5.1$ python essai.py
[{'port': '143', 'host': '10.5.4.1', 'node': '1', 'user_domain': 'rocky9-pve3.org', 'module_uuid': '7cd9a392-ec26-43f3-8691-9fd9ea6678da', 'mail_hostname': 'r3-pve.rocky9-pve3.org', 'transport': 'tcp', 'module_id': 'mail3', 'ui_name': None}]
```
