### PR TITLE
choose a mail_domain for roundcubemail

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -32,7 +32,7 @@ buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui/dist /ui
 # Setup the entrypoint, ask to reserve one TCP port with the label and set a rootless container
 buildah config --entrypoint=/ \
-    --label="org.nethserver.authorizations=traefik@node:routeadm" \
+    --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.images=docker.io/mariadb:10.7.4 docker.io/roundcube/roundcubemail:1.6.0-apache" \

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -29,14 +29,19 @@ config["plugins"] = os.getenv("ROUNDCUBEMAIL_PLUGINS","").replace('archive,zipdo
 config["upload_max_filesize"] = os.getenv("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE","10").replace('M','')
 
 modules=[]
-
+tmp = []
 # we query about all mail server to use it inside the user interface
 for key in agent.list_service_providers(rdb,'imap','tcp'):
-    modules.append({
-        "name": key['module_id'],
-        "label": key['mail_hostname'],
-        "value": key['module_uuid'],
-    })
+    mail = key['module_id']
+    get_retval = agent.tasks.run(f"module/{mail}",'list-domains')
+    for kd in get_retval['output']:
+        if kd['addusers']:
+            obj = {
+                "name": key['module_id'],
+                "label": key['mail_hostname']+' domain: '+kd['domain'],
+                "value": key['module_uuid']+','+kd['domain'],
+            }
+            modules.append(obj)
 
 # use it inside a dropdown
 config['mail_server_URL'] = modules

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,7 +39,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
         if kd['addusers']:
             obj = {
                 "name": key['module_id'],
-                "label": f"{kd['domain']} ({kd['mail_hostname']})",
+                "label": f"{kd['domain']} ({key['mail_hostname']})",
                 "value": key['module_uuid']+','+kd['domain'],
             }
             modules.append(obj)

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,7 +39,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
         if kd['addusers']:
             obj = {
                 "name": key['module_id'],
-                "label": key['mail_hostname']+' domain: '+kd['domain'],
+                "label": "hostname: "+key['mail_hostname']+'    domain: '+kd['domain'],
                 "value": key['module_uuid']+','+kd['domain'],
             }
             modules.append(obj)

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,7 +39,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
         if kd['addusers']:
             obj = {
                 "name": key['module_id'],
-                "label": "hostname: "+key['mail_hostname']+'    domain: '+kd['domain'],
+                "label": f"{kd['domain']} ({kd['mail_hostname']})",
                 "value": key['module_uuid']+','+kd['domain'],
             }
             modules.append(obj)

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -25,6 +25,7 @@ config["lets_encrypt"] = os.getenv("TRAEFIK_LETS_ENCRYPT") == "True"
 rdb = agent.redis_connect() # full read-only access on every key
 
 config["mail_server"] = os.getenv("MAIL_SERVER", "") # the value is the Mail module UUID!
+config["mail_domain"] = os.getenv("MAIL_DOMAIN", "") # the value is the mail domain of user to force domain identity : user@domain.com !
 config["plugins"] = os.getenv("ROUNDCUBEMAIL_PLUGINS","").replace('archive,zipdownload,managesieve,markasjunk,','')
 config["upload_max_filesize"] = os.getenv("ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE","10").replace('M','')
 

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -37,8 +37,8 @@
     "configuring": "Configuring",
     "instance_configuration": "Configure Roundcube",
     "placeholder_plugins": "Plugins list (comma separated: plugin1,plugin2,plugin3)",
-    "choose_mail_server": "Select a mail server as endpoint",
-    "choose_the_mail_server_to_use": "Roundcube needs to connect to a mail server, select one in the list",
+    "choose_mail_server": "Select a mail server as endpoint with the forced mail domain of users",
+    "choose_the_mail_server_to_use": "Roundcube needs to connect to a mail server, select one in the list. By choosing a mail domain you will force the identity of users",
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail"
   },
   "about": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -37,7 +37,7 @@
     "configuring": "Configuring",
     "instance_configuration": "Configure Roundcube",
     "placeholder_plugins": "Plugins list (comma separated: plugin1,plugin2,plugin3)",
-    "choose_mail_server": "Select a domain...",
+    "choose_mail_server": "Select a domain",
     "choose_the_mail_server_to_use": "Choose the domain suffix used for both identifying and initializing the user account and their mail address preferences",
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail"
   },

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -37,8 +37,8 @@
     "configuring": "Configuring",
     "instance_configuration": "Configure Roundcube",
     "placeholder_plugins": "Plugins list (comma separated: plugin1,plugin2,plugin3)",
-    "choose_mail_server": "Select a mail server as endpoint with the forced mail domain of users",
-    "choose_the_mail_server_to_use": "Roundcube needs to connect to a mail server, select one in the list. By choosing a mail domain you will force the identity of users",
+    "choose_mail_server": "Select a domain...",
+    "choose_the_mail_server_to_use": "Choose the domain suffix used for both identifying and initializing the user account and their mail address preferences",
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail"
   },
   "about": {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -352,7 +352,9 @@ export default {
         `${taskAction}-completed-${eventId}`,
         this.configureModuleCompleted
       );
-
+      const tmparray = this.mail_server.split(',');
+      const mail_server_tmp = tmparray[0];
+      const mail_domain_tmp = tmparray[1];
       const res = await to(
         this.createModuleTaskForApp(this.instanceName, {
           action: taskAction,
@@ -360,7 +362,8 @@ export default {
             host: this.host,
             lets_encrypt: this.isLetsEncryptEnabled,
             http2https: this.isHttpToHttpsEnabled,
-            mail_server: this.mail_server,
+            mail_server: mail_server_tmp,
+            mail_domain: mail_domain_tmp,
             plugins: this.plugins,
             upload_max_filesize: parseInt(this.upload_max_filesize),
           },

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -192,6 +192,7 @@ export default {
       isLetsEncryptEnabled: false,
       isHttpToHttpsEnabled: true,
       mail_server: "",
+      mail_domain: "",
       mail_server_URL: [],
       plugins: "",
       upload_max_filesize: "5",
@@ -278,7 +279,13 @@ export default {
       this.upload_max_filesize = config.upload_max_filesize;
       // force to reload mail_server value after dom update
       this.$nextTick(() => {
-        this.mail_server = config.mail_server;
+        const mail_server_tmp = config.mail_server;
+        const mail_domain_tmp = config.mail_domain;
+        if (mail_server_tmp && mail_domain_tmp) {
+          this.mail_server = mail_server_tmp + ',' + mail_domain_tmp;
+        } else {
+          this.mail_server = "";
+        }
       });
 
       this.mail_server_URL = config.mail_server_URL;


### PR DESCRIPTION
![image](https://github.com/NethServer/ns8-roundcubemail/assets/3164851/1c393340-f0a2-42e1-aa6d-eb9053fd2f0b)
![image](https://github.com/NethServer/ns8-roundcubemail/assets/3164851/f7ca2740-69d3-4b90-9db0-27ccdb4161b0)

![image](https://github.com/NethServer/ns8-roundcubemail/assets/3164851/527b41dd-0e32-4744-9a0b-89a64124b7a7)
![image](https://github.com/NethServer/ns8-roundcubemail/assets/3164851/d0c45f2f-614f-452e-bf94-a1b4acddf32e)

roundcubemail is sensible to identity, inside mysql user@domain.org != user@domain.com

If you change the domain of users it is a new users with new addressbooks or settings. Previously we forced the mail_domain from a discovery that was wrong, based on the ldap user_domain

we list the mail domain available with addusers=true and we populate the dropbox with them

see comment of davidep https://github.com/NethServer/ns8-roundcubemail/pull/23#pullrequestreview-1420700069