### PR TITLE
upgrade roundcubemail to 1.6.2 mariadb to 10.11.5 (LTS)

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -35,7 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/mariadb:10.7.4 docker.io/roundcube/roundcubemail:1.6.0-apache" \
+    --label="org.nethserver.images=docker.io/mariadb:10.11.5 docker.io/roundcube/roundcubemail:1.6.0-apache" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -35,7 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/mariadb:10.11.5 docker.io/roundcube/roundcubemail:1.6.0-apache" \
+    --label="org.nethserver.images=docker.io/mariadb:10.11.5 docker.io/roundcube/roundcubemail:1.6.2-apache" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
upgrade roundcubemail to 1.6.2 mariadb to 10.11.5 (LTS)

the mariadb database is well migrated to LTS 10.11.5 ((16 Feb 2028)) and we use roundcubemail 1.6.2