### PR TITLE
implement a check to test if mysql is alive

### DIFF
--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     ${MARIADB_IMAGE} \
     --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 ExecStartPost=/usr/bin/podman exec  mariadb-app /bin/bash -c 'printf "[client] \npassword=Nethesis,1234" > /root/.my.cnf'
+ExecStartPost=/usr/bin/podman exec mariadb-app /bin/bash -c "while ! mysqladmin ping -h localhost -P 3306 -u roundcubemail -proundcubemail; do sleep 1; done"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/mariadb-app.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/mariadb-app.ctr-id
 ExecReload=/usr/bin/podman kill -s HUP mariadb-app

--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -28,7 +28,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     ${MARIADB_IMAGE} \
     --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 ExecStartPost=/usr/bin/podman exec  mariadb-app /bin/bash -c 'printf "[client] \npassword=Nethesis,1234" > /root/.my.cnf'
-ExecStartPost=/usr/bin/podman exec mariadb-app /bin/bash -c "while ! mysqladmin ping -h localhost -P 3306 -u roundcubemail -proundcubemail; do sleep 1; done"
+ExecStartPost=/usr/bin/podman exec mariadb-app /bin/bash -c "while ! mysqladmin ping -h localhost -P 3306 -u root; do sleep 1; done"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/mariadb-app.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/mariadb-app.ctr-id
 ExecReload=/usr/bin/podman kill -s HUP mariadb-app


### PR DESCRIPTION
https://trello.com/c/cY5ixRCl/439-table-roundcubemailcache-doesnt-exist

with some slow IO roundcubemail-app is probably requesting to mariadb-app, we need to be sure it is fully up before to go further 

- log message roundcubemail-app is waiting the end of mariadb-app
https://gist.github.com/stephdl/aff0de634ba582d8bc73f90b7e38f887