### PR TITLE
Fix condition to check for 'addusers' key in get-configuration script

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -36,7 +36,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
     mail = key['module_id']
     get_retval = agent.tasks.run(f"module/{mail}",'list-domains')
     for kd in get_retval['output']:
-        if kd['addusers']:
+        if 'addusers' in kd:
             obj = {
                 "name": key['module_id'],
                 "label": f"{kd['domain']} ({key['mail_hostname']})",

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -36,7 +36,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
     mail = key['module_id']
     get_retval = agent.tasks.run(f"module/{mail}",'list-domains')
     for kd in get_retval['output']:
-        if 'addusers' in kd:
+        if 'addusers' in kd and kd.get('addusers') == True:
             obj = {
                 "name": key['module_id'],
                 "label": f"{kd['domain']} ({key['mail_hostname']})",

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -36,7 +36,7 @@ for key in agent.list_service_providers(rdb,'imap','tcp'):
     mail = key['module_id']
     get_retval = agent.tasks.run(f"module/{mail}",'list-domains')
     for kd in get_retval['output']:
-        if 'addusers' in kd and kd.get('addusers') == True:
+        if kd.get('addusers') == True:
             obj = {
                 "name": key['module_id'],
                 "label": f"{kd['domain']} ({key['mail_hostname']})",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -40,7 +40,8 @@
     "choose_mail_server": "Select a domain",
     "choose_the_mail_server_to_use": "Choose the domain suffix used for both identifying and initializing the user account and their mail address preferences",
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail",
-    "upload_max_filesize_number_lte": "Must be less than 120 MB"
+    "upload_max_filesize_number_lte": "Must be less than 120 MB",
+    "no_available_mail_domain_check_users": "No available mail domain, please check if users are added from user domain"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -41,8 +41,8 @@
     "choose_the_mail_server_to_use": "Choose the domain suffix used for both identifying and initializing the user account and their mail address preferences",
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail",
     "upload_max_filesize_number_lte": "Must be less than 120 MB",
-    "no_available_mail_domain_check_users": "No available mail domain, please check if users are added from user domain",
-    "mail_module_misconfigured": "Mail module is misconfigured"
+    "no_available_mail_domain_check_users": "Make sure the mail domain you intend to use has \"Add user addresses from user domain\" checkbox enabled",
+    "mail_module_misconfigured": "No mail domain available"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -41,7 +41,8 @@
     "choose_the_mail_server_to_use": "Choose the domain suffix used for both identifying and initializing the user account and their mail address preferences",
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail",
     "upload_max_filesize_number_lte": "Must be less than 120 MB",
-    "no_available_mail_domain_check_users": "No available mail domain, please check if users are added from user domain"
+    "no_available_mail_domain_check_users": "No available mail domain, please check if users are added from user domain",
+    "mail_module_misconfigured": "Mail module is misconfigured"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -286,6 +286,16 @@ export default {
         } else {
           this.mail_server = "";
         }
+        // if mail_server_URL is empty, set default value
+        if (this.mail_server_URL.length === 0) {
+          this.mail_server_URL.push({
+            label: this.$t("settings.no_available_mail_domain_check_users"),
+            value: "",
+            name: ""
+          });
+          // we want to avoid to save the form, there is no users set in the mail domain
+          this.mail_server = "";
+        }
       });
 
       this.mail_server_URL = config.mail_server_URL;

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -61,6 +61,16 @@
                 $t("settings.enabled")
               }}</template>
             </cv-toggle>
+            <cv-row v-if="mail_server_URL.length === 0 && ! loading.getConfiguration">
+              <cv-column>
+                <NsInlineNotification
+                  kind="warning"
+                  :title="$t('settings.mail_module_misconfigured')"
+                  :description="$t('settings.no_available_mail_domain_check_users')"
+                  :showCloseButton="false"
+                />
+              </cv-column>
+            </cv-row>
             <NsComboBox
               v-model.trim="mail_server"
               :autoFilter="true"
@@ -288,11 +298,6 @@ export default {
         }
         // if mail_server_URL is empty, set default value
         if (this.mail_server_URL.length === 0) {
-          this.mail_server_URL.push({
-            label: this.$t("settings.no_available_mail_domain_check_users"),
-            value: "",
-            name: ""
-          });
           // we want to avoid to save the form, there is no users set in the mail domain
           this.mail_server = "";
         }


### PR DESCRIPTION
This pull request fixes the condition in the get-configuration script to correctly check for the 'addusers' key. Previously, it was checking for the existence of the key, but now it checks if the key is present in the dictionary. This ensures that the script functions as intended.

![image](https://github.com/NethServer/ns8-roundcubemail/assets/3164851/3fbc8716-7664-4a0a-adae-fa9fbba98512)

https://github.com/NethServer/dev/issues/6837