### PR TITLE
Update roundcubemail version to 1.6.6-apache

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -35,7 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/mariadb:10.11.5 docker.io/roundcube/roundcubemail:1.6.4-apache" \
+    --label="org.nethserver.images=docker.io/mariadb:10.11.5 docker.io/roundcube/roundcubemail:1.6.6-apache" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
This pull request updates the roundcubemail version to 1.6.6-apache. This update includes bug fixes and improvements.

https://github.com/NethServer/dev/issues/6838