### PR TITLE
Update hostname format and add error messages for invalid host pattern and format

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -26,7 +26,8 @@
         "host": {
             "type": "string",
             "description": "Host name for the application, like 'roundcubemail.domain.org'",
-            "format": "idn-hostname"
+            "format": "hostname",
+            "pattern": "\\."
         },
         "lets_encrypt": {
             "type": "boolean",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -42,7 +42,9 @@
     "mail_server_is_not_valid": "This mail server cannot be used by Roundcube webmail",
     "upload_max_filesize_number_lte": "Must be less than 120 MB",
     "no_available_mail_domain_check_users": "Make sure the mail domain you intend to use has \"Add user addresses from user domain\" checkbox enabled",
-    "mail_module_misconfigured": "No mail domain available"
+    "mail_module_misconfigured": "No mail domain available",
+    "host_pattern": "Must be a valid fully qualified domain name",
+    "host_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request updates the hostname format in the `validate-input.json` file to accept fully qualified domain names and adds error messages for invalid host patterns and formats in the `translation.json` file.

https://github.com/NethServer/dev/issues/6853