### PR TITLE
Autodiscover user domain and set environment variable

### DIFF
--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import agent
+
+rdb = agent.redis_connect(use_replica=True)
+event = json.load(sys.stdin)
+
+if not os.environ.get('MAIL_SERVER', ''):
+    exit(0) # ignore event if mail server is not set
+
+providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
+    'module_uuid': os.environ.get('MAIL_SERVER', '')
+})
+
+user_domain = providers[0]['user_domain']
+
+if event.get('domain') != user_domain:
+    exit(0)
+
+agent.run_helper('systemctl', '--user', '-T', 'try-restart', 'roundcubemail.service').check_returncode()


### PR DESCRIPTION
Implement autodiscovery of the user domain upon changes and bind it to the environment variable `USER_DOMAIN`. This ensures the application responds correctly to user domain updates.

https://github.com/NethServer/dev/issues/7103