### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.roundcube.net/doc/help/1.1/en_US/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/roundcube.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-roundcubemail"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `ui/public/metadata.json` file to point to the latest version of the NethServer Roundcube documentation.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL15-R15): Updated the `documentation_url` field to `https://docs.nethserver.org/projects/ns8/en/latest/roundcube.html` to replace the outdated link.

https://github.com/NethServer/dev/issues/7399