### PR TITLE
Update Roundcube image reference and metadata handling

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -30,7 +30,9 @@ cleanup() {
 cp "${metadata_file}" "${metadata_backup}"
 trap cleanup EXIT
 
-sed -i "s/\"upstream_name\": \"[^\"]*\"/\"upstream_name\": \"Roundcube webmail ${roundcube_upstream_version}\"/" "${metadata_file}"
+jq --arg v "${roundcube_upstream_version}" \
+   '.upstream_name |= gsub("version set automatically"; $v)' \
+   "${metadata_file}" > "${metadata_file}.tmp" && mv "${metadata_file}.tmp" "${metadata_file}"
 
 # Create a new empty container image
 container=$(buildah from scratch)

--- a/build-images.sh
+++ b/build-images.sh
@@ -14,6 +14,23 @@ images=()
 repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="roundcubemail"
+roundcube_image="docker.io/roundcube/roundcubemail:1.7.1-apache"
+
+# Extract the upstream version from the image tag, to set it in the metadata
+roundcube_tag="${roundcube_image##*:}"
+roundcube_upstream_version="${roundcube_tag%-apache}"
+metadata_file="ui/public/metadata.json"
+metadata_backup=$(mktemp)
+
+cleanup() {
+    cp "${metadata_backup}" "${metadata_file}"
+    rm -f "${metadata_backup}"
+}
+
+cp "${metadata_file}" "${metadata_backup}"
+trap cleanup EXIT
+
+sed -i "s/\"upstream_name\": \"[^\"]*\"/\"upstream_name\": \"Roundcube webmail ${roundcube_upstream_version}\"/" "${metadata_file}"
 
 # Create a new empty container image
 container=$(buildah from scratch)
@@ -36,7 +53,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.min-core=3.12.4-0" \
-    --label="org.nethserver.images=docker.io/mariadb:10.11.17 docker.io/roundcube/roundcubemail:1.7.1-apache" \
+    --label="org.nethserver.images=docker.io/mariadb:10.11.17 ${roundcube_image}" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -1,5 +1,6 @@
 {
   "name": "Roundcubemail",
+  "upstream_name": "Roundcube webmail (version set automatically)",
   "description": {
     "en": "The Roundcube Webmail suite",
     "it": "Webmail suite Roundcube"

--- a/ui/src/views/About.vue
+++ b/ui/src/views/About.vue
@@ -64,7 +64,7 @@
             </div>
             <div class="key-value-setting">
               <span class="label">{{ core.$t("common.version") }}</span>
-              <span class="value">{{ version }}</span>
+              <span class="value">{{ version }} ({{ app.upstream_name }})</span>
             </div>
             <div class="key-value-setting">
               <span class="label">{{


### PR DESCRIPTION
Update the Roundcube image reference in the build script and adjust the upstream name in the metadata to reflect the new version 1.7.0.