### PR TITLE
Create default folders at first user login

### DIFF
--- a/imageroot/bin/discover-service
+++ b/imageroot/bin/discover-service
@@ -77,6 +77,8 @@ with open("config/config.nethserver.php", "w") as f:
         f.write("$config['mail_domain'] = array('"+imap_server+"' => '"+ user_domain +"'); \n")
     # allow the browser to save login/credential and to fill them
     f.write("$config['login_autocomplete'] = 2; \n")
+    # create default folders at first user login
+    f.write("$config['create_default_folders'] = true; \n")
 
 # retrieve ldap user domain and following shcematype write the addressbook ldap configuration
 lp = Ldapproxy()


### PR DESCRIPTION
Added create_default_folders option to create all default folders, including Sent and Drafts, at first user login. Ref: https://github.com/NethServer/dev/issues/8104