### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -10,15 +10,15 @@ After=roundcubemail.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-# EnvironmentFile=%S/state/secrets/passwords.secret
+EnvironmentFile=%E/state/environment
+# EnvironmentFile=%E/state/secrets/passwords.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mariadb-app.pid %t/mariadb-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     --cidfile %t/mariadb-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/roundcubemail.pod-id --replace -d --name mariadb-app \
-    --env-file=%S/state/environment \
+    --env-file=%E/state/environment \
     --volume mysql-data:/var/lib/mysql/:Z \
     --env MARIADB_ROOT_PASSWORD=Nethesis,1234 \
     --env MARIADB_DATABASE=roundcubemail \

--- a/imageroot/systemd/user/roundcubemail-app.service
+++ b/imageroot/systemd/user/roundcubemail-app.service
@@ -10,9 +10,9 @@ After=roundcubemail.service mariadb-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/discovery.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+EnvironmentFile=-%E/state/discovery.env
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/mkdir -p config

--- a/imageroot/systemd/user/roundcubemail.service
+++ b/imageroot/systemd/user/roundcubemail.service
@@ -15,7 +15,7 @@ Before=mariadb-app.service roundcubemail-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=-%S/state/environment
+EnvironmentFile=-%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/roundcubemail.pid %t/roundcubemail.pod-id


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host